### PR TITLE
Fix Race condition / NPE when input bind haven't fired yet

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -362,7 +362,7 @@
     if (debug) {
       console.log("Seaching DOM element: " + query + " in " + list);
     }
-    const el = list.querySelector(query);
+    const el = list && list.querySelector(query);
     if (el) {
       if (typeof el.scrollIntoViewIfNeeded === "function") {
         if (debug) {


### PR DESCRIPTION
Sometimes, it is possible to get this exception below on the first autocomplete render. 

![image](https://user-images.githubusercontent.com/8777372/100482387-33c26300-30c5-11eb-89a0-127ff1781313.png)

Which happens here
https://github.com/pstanoev/simple-svelte-autocomplete/blob/master/src/SimpleAutocomplete.svelte#L461
then https://github.com/pstanoev/simple-svelte-autocomplete/blob/master/src/SimpleAutocomplete.svelte#L519
then https://github.com/pstanoev/simple-svelte-autocomplete/blob/master/src/SimpleAutocomplete.svelte#L365


Because list hasn't been binded to an input element yet. https://github.com/pstanoev/simple-svelte-autocomplete/blob/master/src/SimpleAutocomplete.svelte#L729 
Meaning, this is a race condition since https://github.com/pstanoev/simple-svelte-autocomplete/blob/master/src/SimpleAutocomplete.svelte#L490 is triggering an update, but it is asynchronous, as seen from compiled code:
```
 $$invalidate('filteredListItems', filteredListItems = listItems);
```
or
```
function input_1_binding($$value) {
    		binding_callbacks[$$value ? 'unshift' : 'push'](() => {
    			$$invalidate('input', input = $$value);
    		});
    	} // interchangeable with div binding
```
which results in call stack:
![image](https://user-images.githubusercontent.com/8777372/100483318-7afd2380-30c6-11eb-9ffc-a2a7bebd23c1.png)
Which is a promise

This patch fixes that issue by adding a simple check.