### PR TITLE
Improve highlighting of dropdown items

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -680,7 +680,6 @@
     line-height: 1;
   }
 
-  .autocomplete-list-item:hover,
   .autocomplete-list-item.selected {
     background-color: #2e69e2;
     color: #fff;
@@ -746,7 +745,8 @@
           {#if listItem}
             <div
               class="autocomplete-list-item {i === highlightIndex ? 'selected' : ''}"
-              on:click={() => onListItemClick(listItem)}>
+              on:click={() => onListItemClick(listItem)}
+              on:pointerenter={() => {highlightIndex = i;}}>
               {#if listItem.highlighted}
                 {@html listItem.highlighted.label}
               {:else}


### PR DESCRIPTION
Previously dropdown items have been highlighted by two independent
mechanisms
- by keeping the index of highlighted item highlightIndex (for keyboard),
- by css :hover (for mouse).

This caused that often two different items have been highlighted at the
same time - one selected by keyboard, the other by hovering the mouse.

This commit makes the two mechaninsms work seamlessly together so that
at each moment only one item is highlighted. Using mouse and keybord can
be arbitrarily combined.