### PR TITLE
html5autocomplete flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Props you may want to specify include:
 - `dropdownClassName` - apply a className to the dropdown div showing the list of items
 - `name` - generate an HTML input with this name, containing the current value
 - `debug` - flag to enable detailed log statements from the component
+- `html5autocomplete` - flag to enable or disable the [HTML5 autocomplete](https://developer.mozilla.org/fr/docs/Web/HTML/Element/form#attr-autocomplete) attribute
 
 #### CSS properties
 - `autocomplete` the class applied to the main control

--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -129,6 +129,9 @@
   export let title = undefined;
   export let debug = false;
 
+  // enable the html5 autocompletion
+  export let html5autocomplete = undefined;
+
   // selected item state
   export let selectedItem = undefined;
   export let value = undefined;
@@ -722,6 +725,7 @@
     type="text"
     class="{inputClassName ? inputClassName : ''} input autocomplete-input"
     id={inputId ? inputId : ''}
+    autocomplete={html5autocomplete ? 'on' : 'off'}
     {placeholder}
     {name}
     {disabled}


### PR DESCRIPTION
Fixes #33

This adds a `html5autocomplete` flag, that is disabled by default.