### PR TITLE
Implemented a delay parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Props you may want to specify include:
 - `minCharactersToSearch` - minimum length of search text to perform search, defaults to 1
 - `maxItemsToShowInList` - maximum number of items to show in the dropdown list, defaults 0 (no limit)
 - `disabled` - disable the control
+- `delay` - the delay to wait after an input to call `searchFunction` (in milliseconds) defaults to 0. A value like 200 allows to not
+   produce too many requests.
 
 ### Events
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -157,5 +157,17 @@ let selectedColorValue;
       <p>Selected country: {JSON.stringify(selectedCountry)}</p>
     </div>
 
+    <h3>Delay example:</h3>
+    <p>The component waits 1 second after you typed something before generating a request. You
+    can open your browser network panel, and see that there has probably been fewer requests than
+    character you typed.</p>
+    <h5>Pick a country:</h5>
+    <AutoComplete
+      searchFunction={searchCountry}
+      bind:selectedItem={selectedCountry}
+      labelFieldName="name"
+      maxItemsToShowInList="10"
+      delay=1000 />
+
   </div>
 </section>

--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -135,6 +135,10 @@
   // selected item state
   export let selectedItem = undefined;
   export let value = undefined;
+
+  // delay to wait after a keypress to search for new items
+  export let delay = 0;
+
   let text;
   let filteredTextLength = 0;
 
@@ -161,6 +165,8 @@
   let filteredListItems;
 
   let listItems = [];
+
+  let timeout;
 
   function prepareListItems() {
     let tStart;
@@ -452,6 +458,19 @@
     }
 
     text = e.target.value;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    if (delay) {
+      timeout = setTimeout(process_input, delay);
+    }
+    else {
+      process_input();
+    }
+  }
+
+  function process_input() {
     search();
     highlightIndex = 0;
     open();


### PR DESCRIPTION
Related to #42

As discussed in #42, right now a new async request is emitted each time the user press a key. Generally only the final sentence/word typed is useful, but not the intermediary steps. Setting a delay to something like `200` allow to reduce the number of requests emitted.

Javascript is not really my predilection language, so I might do things the wrong way. Do not hesitate to tell me what to fix.