### PR TITLE
Multiple selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Autocomplete / Select / Typeahead component made with [Svelte](https://svelte.de
 * option to define a label field or function
 * option to define more fields used for search
 * support for async load of items
+* can hold one or several values
 
 
 ## Install
@@ -113,6 +114,7 @@ async function getItems(keyword) {
 
 ### Behaviour
 
+- `multiple` - enable multiple selection (false by default)
 - `items` - array of items the user can select from (optional, use `searchFunction` for async loading of items)
 - `searchFunction` - optional function to load items asynchroniously from HTTP call for example, the searchFunction can also return all items and addtional local search will still be performed
 - `delay` - delay in miliseconds to wait after user input to do the local searching or call `searchFunction` if provided, defaults to 0
@@ -153,6 +155,8 @@ async function getItems(keyword) {
 - `name` - generate an HTML input with this name, containing the current value
 - `debug` - flag to enable detailed log statements from the component
 - `html5autocomplete` - flag to enable or disable the [HTML5 autocomplete](https://developer.mozilla.org/fr/docs/Web/HTML/Element/form#attr-autocomplete) attribute
+- `selectName` - apply a name attribute to the <select> tag that holds the selected value
+- `selectId` - apply an id attribute to the <select> tag that holds the selected value
 
 ### UI Slots
 - `item` - change the apearance of items in the dropdown list:
@@ -178,6 +182,12 @@ The noResultsText variable is optional and can be ommited.
 </div>
 </pre>
 ```
+- `tag` - customize the tag blocks displayed when multiple selection is enabled:
+```html
+<slot name="tag" let:label={label} let:item={item} let:unselectItem={unselectItem}>
+  <span class="tag">{label}</span>
+  <span class="delete-tag" on:click|preventDefault={unselectItem(item)}></span>
+</slot>```
 
 #### CSS properties
 - `autocomplete` the class applied to the main control

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,6 +7,8 @@
 
   let selectedColor;
   let selectedAnimal;
+  let selectedColorsItems;
+  let selectedColorsValues;
   let items = countryList;
   let selectedCountry;
 
@@ -137,6 +139,18 @@ async function* searchCountryGenerator(keyword) {
   delay=200
   localFiltering=false />`;
 
+  const example7Code = `let selectedColorsItems;
+let selectedColorsValues;
+
+<AutoComplete
+    multiple=true
+    items={colorList}
+    labelFieldName="name"
+    valueFieldName="id"
+    bind:selectedItem={selectedColorsItems}
+    bind:value={selectedColorsValues}
+    />`;
+
 
   async function searchCountry(keyword) {
     const url =
@@ -234,6 +248,38 @@ async function* searchCountryGenerator(keyword) {
             <code class="language-html" data-lang="html">{example2Code}</code>
           </pre>
         </div>
+      </div>
+    </div>
+
+    <h3>Multiple example:</h3>
+    <p>
+    The <strong>multiple</strong> attribute allows you to select several items
+    </p>
+
+    <div class="columns">
+      <div class="column is-one-third">
+        <h5>Pick a color:</h5>
+
+        <AutoComplete
+            multiple=true
+            items={colorList}
+            labelFieldName="name"
+            valueFieldName="id"
+            showClear={true}
+            bind:selectedItem={selectedColorsItems}
+            bind:value={selectedColorsValues}
+            />
+        <p>
+          Selected color items: {JSON.stringify(selectedColorsItems)}
+          <br />
+          Selected color values: {JSON.stringify(selectedColorsValues)}
+        </p>
+
+      </div>
+      <div class="column">
+        <pre>
+          <code class="language-html" data-lang="html">{example7Code}</code>
+        </pre>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #55
![multiple](https://user-images.githubusercontent.com/60163/116524231-6f14c800-a8d7-11eb-9747-ee4ef0a7a9c9.gif)

I implemented multiple selection:
- enabled when `multiple` is set to `true`
- one click on a list item selects it, a second one unselect it
- selecting a list item resets the input text
- when there is no input text, pressing `backspace` deletes the last tag

Almost all of the code is straightforward, but there is one matter you will probably want to discuss: there is a new `<select>` tag that holds the value(s) in addition to the `<input>` that collects the user input.
Right now its name and id are defined with `selectName` and `selectId`.
Now for someone (as me) who will send the form, even in non-multiple selection cases, it has value to have another tag holding the actual value (and not only the input text). That would fix #40 and set good bases for #52.

What do you think?