### PR TITLE
Matches items even if diacritics differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ async function getItems(keyword) {
 - `minCharactersToSearch` - minimum length of search text to perform search, defaults to 1
 - `maxItemsToShowInList` - maximum number of items to show in the dropdown list, defaults 0 (no limit)
 - `disabled` - disable the control
+- `ignoreAccents` - ignores the accents to match items, defaults to true.
 
 ### Events
 

--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -167,7 +167,7 @@
     // console.log("safeKeywordsFunction");
     const keywords = safeStringFunction(keywordsFunction, item);
     let result = safeStringFunction(keywordsCleanFunction, keywords);
-    result = result.toLowerCase().trim();
+    result = removeDiacritics(result.toLowerCase().trim());
     if (debug) {
       console.log(
         "Extracted keywords: '" +
@@ -293,7 +293,7 @@
     // local search
     let tempfilteredListItems;
     if (localFiltering) {
-      const searchWords = textFiltered.split(" ");
+      const searchWords = removeDiacritics(textFiltered).split(" ");
 
       tempfilteredListItems = listItems.filter(listItem => {
         if (!listItem) {
@@ -638,6 +638,10 @@
       }
       return newI;
     };
+  }
+
+  function removeDiacritics(str) {
+    return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
   }
 </script>
 

--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -89,6 +89,9 @@
   // adds the disabled tag to the HTML input
   export let disabled = false;
 
+  // ignores the accents when matching items
+  export let ignoreAccents = true;
+
   export let debug = false;
 
   // --- Public State ----
@@ -167,7 +170,11 @@
     // console.log("safeKeywordsFunction");
     const keywords = safeStringFunction(keywordsFunction, item);
     let result = safeStringFunction(keywordsCleanFunction, keywords);
-    result = removeDiacritics(result.toLowerCase().trim());
+    result = result.toLowerCase().trim();
+    if (ignoreAccents) {
+      result = removeDiacritics(result);
+    }
+
     if (debug) {
       console.log(
         "Extracted keywords: '" +
@@ -293,7 +300,10 @@
     // local search
     let tempfilteredListItems;
     if (localFiltering) {
-      const searchWords = removeDiacritics(textFiltered).split(" ");
+      var searchWords = textFiltered.split(" ");
+      if (ignoreAccents) {
+        searchWords = searchWords.map(word => removeDiacritics(word));
+      }
 
       tempfilteredListItems = listItems.filter(listItem => {
         if (!listItem) {


### PR DESCRIPTION
Fixes #57
In the demo, if you type `réd` for instance, then `red` will be matched.
The inverse is true too, inputs without accents will match items with accents.