### PR TITLE
Allow to send the form by pressing Enter

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -464,7 +464,7 @@
       console.log("onKeyPress");
     }
 
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && opened) {
       e.preventDefault();
       selectItem();
     }


### PR DESCRIPTION
With this patch `Enter` is only catched when the menu is opened. This way one can submit a form by pressing `Enter` when the menu is closed. This is the default behavior for most of the browsers with regular forms.