### PR TITLE
Lockable input

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ async function getItems(keyword) {
 - `ignoreAccents` - ignores the accents to match items, defaults to true.
 - `matchAllKeywords` - defaults to true. If false, any item will be suggested if it shares at least one common keyword with the input.
 - `sortByPertinence` - defaults to false. If true, items are sorted by pertinence.
+- `lock` - defaults to false. Locks the input when an item has been selected.
 
 ### Events
 
@@ -157,6 +158,7 @@ async function getItems(keyword) {
 - `html5autocomplete` - flag to enable or disable the [HTML5 autocomplete](https://developer.mozilla.org/fr/docs/Web/HTML/Element/form#attr-autocomplete) attribute
 - `selectName` - apply a name attribute to the <select> tag that holds the selected value
 - `selectId` - apply an id attribute to the <select> tag that holds the selected value
+- `readonly` - make the input readonly
 
 ### UI Slots
 - `item` - change the apearance of items in the dropdown list:

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@ import AutoComplete from "./SimpleAutocomplete.svelte";
 
 import SimpleExample from "./SimpleExample.svelte";
 import AdvancedExample from "./AdvancedExample.svelte";
+import LockedExample from "./LockedExample.svelte";
 import MultipleExample from "./MultipleExample.svelte";
 import CustomizationExample from "./CustomizationExample.svelte";
 import ActivityIndicatorExample from "./ActivityIndicatorExample.svelte";
@@ -29,6 +30,7 @@ import AsyncGeneratorExample from "./AsyncGeneratorExample.svelte";
         </p>
 
         <SimpleExample />
+        <LockedExample />
         <AdvancedExample />
         <MultipleExample />
         <CustomizationExample />

--- a/src/LockedExample.svelte
+++ b/src/LockedExample.svelte
@@ -1,0 +1,36 @@
+<script>
+import AutoComplete from "./SimpleAutocomplete.svelte";
+import Highlight from "svelte-highlight";
+import xml from "svelte-highlight/src/languages/xml";
+
+let selectedColor;
+const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black"];
+const code = `<script>
+const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black"];
+let selectedColor;
+<\/script>
+
+<AutoComplete items={colors} bind:selectedItem={selectedColor} lock={true} />
+Selected color: {selectedColor}`;
+</script>
+
+<div>
+    <h3>Simple lock example:</h3>
+    <p>
+        This example is liked the previous one except that the input is <em>lock</em>. This means that only the suggested values are available.
+    </p>
+
+    <div class="columns">
+        <div class="column is-one-third">
+            <h5>Pick a color:</h5>
+
+            <AutoComplete items={colors} bind:selectedItem={selectedColor} lock={true} />
+            <p>Selected color: {selectedColor}</p>
+
+        </div>
+
+        <div class="column">
+            <Highlight language="{xml}" {code} />
+        </div>
+    </div>
+</div>

--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -54,6 +54,7 @@
   export let minCharactersToSearch = 1;
   export let maxItemsToShowInList = 0;
   export let multiple = false;
+  export let lock = false;
 
   // delay to wait after a keypress to search for new items
   export let delay = 0;
@@ -89,6 +90,8 @@
   export let title = undefined;
   // enable the html5 autocompletion to the HTML input
   export let html5autocomplete = undefined;
+  // make the input readonly
+  export let readonly = undefined;
 
   // apply a className to the dropdown div
   export let dropdownClassName = undefined;
@@ -155,6 +158,8 @@
 
   $: showList =
     opened && ((items && items.length > 0) || filteredTextLength > 0);
+
+  $: clearable = showClear || ((lock || multiple) && selectedItem)
 
   // --- Functions ---
   function safeStringFunction(theFunction, argument) {
@@ -973,7 +978,8 @@
   class="{className ? className : ''}
   {hideArrow || !items.length ? 'hide-arrow' : ''}
   {multiple ? 'is-multiple' : ''}
-  {showClear ? 'show-clear' : ''} autocomplete select is-fullwidth {uniqueId}"
+  autocomplete select is-fullwidth {uniqueId}"
+  class:show-clear={clearable}
   class:is-loading={loading}
   >
   <select
@@ -1010,14 +1016,16 @@
     {name}
     {disabled}
     {title}
+    readonly={readonly || (lock && selectedItem)}
     bind:this={input}
     bind:value={text}
     on:input={onInput}
     on:focus={onFocus}
     on:keydown={onKeyDown}
     on:click={onInputClick}
-    on:keypress={onKeyPress} />
-  {#if showClear}
+    on:keypress={onKeyPress}
+    />
+  {#if clearable}
     <span on:click={clear} class="autocomplete-clear-button">&#10006;</span>
   {/if}
   </div>


### PR DESCRIPTION
Fixed #52 

This adds two properties:
- lock: that locks the input when an item is selected
- readonly: that allows users to make the input field readonly