### PR TITLE
Fixed non-async highlighting

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -331,8 +331,12 @@
       return;
     }
 
+    if (!searchFunction) {
+        processListItems(textFiltered);
+    }
+
     // external search which provides items
-    if (searchFunction) {
+    else{
       lastRequestId = lastRequestId + 1;
       var currentRequestId = lastRequestId;
       loading = true;
@@ -661,7 +665,9 @@
       console.log("resetListToAllItemsAndOpen");
     }
 
-    filteredListItems = listItems;
+    if (!text) {
+        filteredListItems = listItems;
+    }
 
     open();
 


### PR DESCRIPTION
This fixes a bug introduced with #54, that broke non-async highlighting, because `processListItems` was not called at the end of the `search` function.

This also fixes #64