### PR TITLE
If using a search function clear items on empty search string

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -325,12 +325,24 @@
     const textFiltered = prepareUserEnteredText(text);
 
     if (textFiltered === "") {
-      filteredListItems = listItems;
+      if (searchFunction) {
+        // we will need to rerun the search
+        items = [];
+        if (debug) {
+          console.log(
+            "User entered text is empty clear list of items"
+          );
+        }
+      } else {
+        filteredListItems = listItems;
+        if (debug) {
+          console.log(
+            "User entered text is empty set the list of items to all items"
+          );
+        }
+      }
       closeIfMinCharsToSearchReached();
       if (debug) {
-        console.log(
-          "User entered text is empty set the list of items to all items"
-        );
         console.timeEnd(timerId);
       }
       return;


### PR DESCRIPTION
Fixes #60 

If the user is using a search function to populate the list (e.g. using it to fetch results from remote server) then clear the items when the user provides an empty string.

This causes the search box to close as expected.