### PR TITLE
Add a checkbox in the demo page to disable bulma

### DIFF
--- a/public/default.css
+++ b/public/default.css
@@ -1,0 +1,39 @@
+body {
+    padding: 0 3em;
+    font-family:helvetica;
+}
+
+ul{
+    list-style-type: none;
+}
+
+.tabs{
+    text-align: center;
+}
+
+.tab{
+    cursor: pointer;
+    display: inline-block;
+    margin: auto 1em;
+}
+
+.tab:hover{
+    color: #6c71c4;
+}
+
+.tab-content.is-hidden{
+    display: none;
+}
+
+.tab.is-active{
+    color: #268bd2;
+}
+
+.column{
+     display: inline-block;
+     width: 66%;
+}
+
+.column.is-one-third{
+     width: 33%;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -6,13 +6,11 @@
 
 	<title>Svelte Simple Autocomplete Demo</title>
 
-	<link rel="stylesheet" href="bulma.css">
-	<link rel='stylesheet' href='bundle.css'>
+    <link rel='stylesheet' href='bundle.css'>
 
 	<script defer src='bundle.js'></script>
     <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
 </head>
-
 <body>
 </body>
 </html>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,8 @@
   import AsyncPreloadedExample from "./demo/AsyncPreloadedExample.svelte";
   import CreatableExample from "./demo/CreatableExample.svelte";
 
+  let bulma = true;
+
   function showTab(e, tab) {
     console.log("Show tab", e, tab);
     for (let el of document.getElementsByClassName("tab")) {
@@ -42,18 +44,26 @@
 
 <svelte:head>
   {@html solarized}
+  {#if bulma}
+    <link rel="stylesheet" href="bulma.css">
+  {:else}
+    <link rel="stylesheet" href="default.css">
+  {/if}
 </svelte:head>
+
 <section class="section">
   <div class="container content">
     <h1 class="title">Svelte Simple Autocomplete Demo</h1>
-
     <p>
       <a href="https://github.com/pstanoev/simple-svelte-autocomplete">
         <i class="fab fa-github" />
         https://github.com/pstanoev/simple-svelte-autocomplete
       </a>
     </p>
-
+    <div class="field">
+      <input class=is-checkradio id=bulma type=checkbox bind:checked={bulma}>
+      <label for="bulma">Bulma</label>
+    </div>
     <div class="tabs is-centered">
       <ul class="ml-0">
         <li


### PR DESCRIPTION
This patch adds a checkbox to the demo webpage to let users disable bulma style. This should help to debug style without bulma, and let the users see the default style of the component.

![Screenshot 2021-07-20 at 19-39-11 Svelte Simple Autocomplete Demo](https://user-images.githubusercontent.com/60163/126370672-af1b8550-ea8f-4e62-9fca-8ce3482fd727.png)
