### PR TITLE
Fixed a situation when async generators returned no value

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -397,6 +397,13 @@
           items = [...items, ...chunk];
           processListItems(textFiltered);
         }
+
+        // there was nothing in the chunk
+        if (lastResponseId < currentRequestId) {
+          lastResponseId = currentRequestId
+          items = []
+          processListItems(textFiltered);
+        }
       }
 
       // searchFunction is a regular function

--- a/src/demo/AsyncGeneratorExample.svelte
+++ b/src/demo/AsyncGeneratorExample.svelte
@@ -13,7 +13,7 @@ async function* searchCountryGenerator(keyword) {
 
     const response = await fetch(url);
     const chunks = await response.json();
-    if (chunks) {
+    if (response.status == 200 && chunks) {
         for (const chunk of chunks) {
             yield [chunk];
             await new Promise(r => setTimeout(r, 1000));


### PR DESCRIPTION
This bugfix concerns async generators.
Previously, when an unsuccessful search B was done after a successful one A, the menu would display the A results until another successful search was done.