### PR TITLE
Fix reactivity for onCreate

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -1,4 +1,6 @@
 <script>
+  import {tick} from "svelte";
+
   // the list of items  the user can select from
   export let items = [];
 
@@ -502,13 +504,14 @@
 
   // $: text, search();
 
-  function selectListItem(listItem) {
+  async function selectListItem(listItem) {
     if (debug) {
       console.log("selectListItem", listItem);
     }
     if ("undefined" === typeof listItem && create) {
       // allow undefined items if create is enabled
       const createdItem = onCreate(text);
+      await tick();
       if ("undefined" !== typeof createdItem) {
         prepareListItems();
         filteredListItems = listItems;
@@ -550,12 +553,12 @@
     return true;
   }
 
-  function selectItem() {
+  async function selectItem() {
     if (debug) {
       console.log("selectItem", highlightIndex);
     }
     const listItem = filteredListItems[highlightIndex];
-    if (selectListItem(listItem)) {
+    if (await selectListItem(listItem)) {
       close();
       if (multiple) {
         input.focus();
@@ -619,12 +622,12 @@
     }
   }
 
-  function onListItemClick(listItem) {
+  async function onListItemClick(listItem) {
     if (debug) {
       console.log("onListItemClick");
     }
 
-    if (selectListItem(listItem)) {
+    if (await selectListItem(listItem)) {
       close();
       if (multiple) {
         input.focus();

--- a/src/demo/CreatableExample.svelte
+++ b/src/demo/CreatableExample.svelte
@@ -3,7 +3,7 @@
   import Highlight from "svelte-highlight";
   import xml from "svelte-highlight/src/languages/xml";
 
-  const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black"];
+  let colors = ["White", "Red", "Yellow", "Green", "Blue", "Black"];
   let selectedColor;
   let text = "Non existing color";
   let toCreate = "";
@@ -12,14 +12,13 @@ const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black"];
 let selectedColor;
 let text = 'Non existing color'
 let toCreate = "";
-<\/script>
 
 function handleCreate(newColor) {
-  toCreate = 'Creating ' + newColor; 
-  colors.unshift(newColor);
-  colors = colors;
+  toCreate = 'Creating ' + newColor;
+  colors = [newColor, ...colors];
   return newColor
 }
+<\/script>
 
 <AutoComplete
   items={colors}
@@ -32,13 +31,10 @@ Current user entered text: {text}<br />
 Selected color: {selectedColor}`;
 
  function handleCreate(newColor) {
-    toCreate = 'Creating ' + newColor; 
-    colors.unshift(newColor);
-    colors = colors;
+    toCreate = 'Creating ' + newColor;
+    colors = [newColor, ...colors];
     return newColor
   }
-
-  
 </script>
 
 <div>


### PR DESCRIPTION
Fixes #102 
`onCreate` with store doesn't work because we use `items` before it's updated with `onCreate`

You used a hack with `unshift` in your example
```js
function handleCreate(newColor) {
  toCreate = 'Creating ' + newColor; 
  colors.unshift(newColor);
  colors = colors;
  return newColor
}
```
`colors` stays the same object (same link), but it doesn't work with store or svelte-way reactive array update (like `colors = [newColor, ...colors]`)

So, we need to wait for reactive `items` update before finding created item 