### PR TITLE
fixed dropdown auto closing issue

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -634,9 +634,9 @@
 
   function onDocumentClick(e) {
     if (debug) {
-      console.log("onDocumentClick: " + JSON.stringify(e.target));
+      console.log("onDocumentClick: " + JSON.stringify(e.composedPath()));
     }
-    if (e.target.closest("." + uniqueId)) {
+    if (e.composedPath().some(path => path.classList && path.classList.contains(uniqueId))) {
       if (debug) {
         console.log("onDocumentClick inside");
       }


### PR DESCRIPTION
When using the component inside a web component created with using Svelte framework, the dropdown opens when clicking the input field, but automatically closes right after. This behavior happens because, in case of a web component, events that happen in shadow DOM have the host element as the target, when caught outside of the component. 
For that reason 
           if (e.target.closest("." + uniqueId))
will always return false, so the dropdown will close.