### PR TITLE
Fix autocomplete="off" for Chrome

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -1167,7 +1167,7 @@
       type="text"
       class="{inputClassName ? inputClassName : ''} input autocomplete-input"
       id={inputId ? inputId : ''}
-      autocomplete={html5autocomplete ? 'on' : 'off'}
+      autocomplete={html5autocomplete ? 'on' : 'some-other-text'}
       {placeholder}
       {name}
       {disabled}


### PR DESCRIPTION
Hello,
Chrome (Brave and others) ignore autocomplete="off". More on that issue here
https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off

So we can use some other text in autocomplete  field or user input type="search" as it said here https://stackoverflow.com/a/30873633