### PR TITLE
[#112] fixed late update of choice items 

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -170,30 +170,6 @@
   let inputDelayTimeout;
 
   // -- Reactivity --
-  function onSelectedItemChanged() {
-    value = valueFunction(selectedItem);
-    text = !multiple ? safeLabelFunction(selectedItem) : "";
-
-    filteredListItems = listItems;
-    onChange(selectedItem);
-  }
-
-  $: selectedItem, onSelectedItemChanged();
-
-  $: highlightedItem =
-    filteredListItems &&
-    highlightIndex &&
-    highlightIndex >= 0 &&
-    highlightIndex < filteredListItems.length
-      ? filteredListItems[highlightIndex].item
-      : null;
-
-  $: showList =
-    opened && ((items && items.length > 0) || filteredTextLength > 0);
-
-  $: clearable = showClear || ((lock || multiple) && selectedItem);
-
-  // --- Functions ---
   function safeStringFunction(theFunction, argument) {
     if (typeof theFunction !== "function") {
       console.error(
@@ -298,6 +274,30 @@
 
   $: items, prepareListItems();
 
+  function onSelectedItemChanged() {
+    value = valueFunction(selectedItem);
+    text = !multiple ? safeLabelFunction(selectedItem) : "";
+
+    filteredListItems = listItems;
+    onChange(selectedItem);
+  }
+
+  $: selectedItem, onSelectedItemChanged();
+
+  $: highlightedItem =
+          filteredListItems &&
+          highlightIndex &&
+          highlightIndex >= 0 &&
+          highlightIndex < filteredListItems.length
+                  ? filteredListItems[highlightIndex].item
+                  : null;
+
+  $: showList =
+          opened && ((items && items.length > 0) || filteredTextLength > 0);
+
+  $: clearable = showClear || ((lock || multiple) && selectedItem);
+
+  // --- Functions ---
   function prepareUserEnteredText(userEnteredText) {
     if (userEnteredText === undefined || userEnteredText === null) {
       return "";


### PR DESCRIPTION
The issue is fixed by a change in the order of handling changes reactively (first `items`, and then `selectedItems`). 

This is a very small change to the control flow and only "local", because it affects only the case when simple-svelte-autocomplete is used with the `items` attribute and everything stay the same for the case of using `searchFunction`. 

The fix solves problem in the minimal example, see this branch: https://github.com/nika-d/autocomplete-minimal-example/tree/fixing  .