### PR TITLE
Add import to first example

### DIFF
--- a/src/demo/SimpleExample.svelte
+++ b/src/demo/SimpleExample.svelte
@@ -7,6 +7,8 @@ let selectedColor;
 let highlightedColor;
 const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black", "Mät bläck", "<i>Jét Black</i>"];
 const code = `<script>
+import AutoComplete from 'simple-svelte-autocomplete';
+
 const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black", "Mät bläck", "<i>Jét Black</i>];
 let selectedColor;
 <\/script>


### PR DESCRIPTION
This allows a new user to have a copyable example without the need to figure out how to import `AutoComplete`.

I'd say adding it to the first example is enough, but I can add it to the other examples if you prefer repeating it.