### PR TITLE
Fix invalid example code 

### DIFF
--- a/src/demo/SimpleExample.svelte
+++ b/src/demo/SimpleExample.svelte
@@ -4,17 +4,16 @@ import Highlight from "svelte-highlight";
 import xml from "svelte-highlight/src/languages/xml";
 
 let selectedColor;
-let highlightedColor;
 const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black", "Mät bläck", "<i>Jét Black</i>"];
 const code = `<script>
 import AutoComplete from 'simple-svelte-autocomplete';
 
-const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black", "Mät bläck", "<i>Jét Black</i>];
+const colors = ["White", "Red", "Yellow", "Green", "Blue", "Black", "Mät bläck", "<i>Jét Black</i>"];
 let selectedColor;
 <\/script>
 
 Selected color: {selectedColor}
-<AutoComplete items={colors} bind:selectedItem={selectedColor} bind:highlightedItem={highlightedColor} />`;
+<AutoComplete items={colors} bind:selectedItem={selectedColor} />`;
 </script>
 
 <div>
@@ -26,7 +25,7 @@ Selected color: {selectedColor}
 
             <p>Selected color: {selectedColor}</p>
            
-            <AutoComplete items={colors} bind:selectedItem={selectedColor} bind:highlightedItem={highlightedColor} />
+            <AutoComplete items={colors} bind:selectedItem={selectedColor} />
 
         </div>
 


### PR DESCRIPTION
Thank you for sharing this very useful component!

I noticed the first code example does not run due to a typo and an unused `highlightedItem`. This pull request should fix that.