### PR TITLE
Updated html5autocomplete to be "off" when falsy

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -1170,7 +1170,7 @@
       type="text"
       class="{inputClassName ? inputClassName : ''} input autocomplete-input"
       id={inputId ? inputId : ''}
-      autocomplete={html5autocomplete ? 'on' : 'some-other-text'}
+      autocomplete={html5autocomplete ? 'on' : 'off'}
       {placeholder}
       {name}
       {disabled}


### PR DESCRIPTION
This fixes an issue with Chrome where it still autofills previous responses to this field.

The [Mozilla definition for the `autocomplete` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-autocomplete) allows two values: `on` or `off`.