### PR TITLE
skip client side input text filtering when request are done serverside

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -282,21 +282,12 @@
 
   $: clearable = showClear || ((lock || multiple) && selectedItem)
 
-  function prepareUserEnteredText(userEnteredText) {
+  function cleanSearchQuery(userEnteredText) {
     if (userEnteredText === undefined || userEnteredText === null) {
       return ""
     }
 
     const textFiltered = userEnteredText.replace(/[&/\\#,+()$~%.'":*?<>{}]/g, " ").trim()
-
-    filteredTextLength = textFiltered.length
-
-    if (minCharactersToSearch > 1) {
-      if (filteredTextLength < minCharactersToSearch) {
-        return ""
-      }
-    }
-
     const cleanUserEnteredText = textCleanFunction(textFiltered)
     const textFilteredLowerCase = cleanUserEnteredText.toLowerCase().trim()
 
@@ -333,7 +324,13 @@
       console.log("Searching user entered text: '" + text + "'")
     }
 
-    const textFiltered = prepareUserEnteredText(text)
+    const textFiltered = searchFunction ? text : cleanSearchQuery(text)
+
+    if (minCharactersToSearch > 1) {
+      if (textFiltered.length < minCharactersToSearch) {
+        return
+      }
+    }
 
     if (textFiltered === "") {
       if (searchFunction) {


### PR DESCRIPTION
I encountered a usecase where filtering was done serverside, and a user input contained a dot `.`, but the server response seemed incoherent. I saw that the dot was deleted by `prepareUserEnteredText`.

If filtering is done serverside (i.e. there is a `searchFunction`) then the input cleaning (i.e. `prepareUserEnteredText`) should also be done serverside.

With this patch, `prepareUserEnteredText` is not called if `searchFunction` is defined.

If you want, I can make this behavior optional.