### PR TITLE
New option: remove InputStyles

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -134,6 +134,8 @@
   export let dropdownClassName = undefined
   // adds the disabled tag to the HTML input
   export let disabled = false
+  // remove the autocomplete-input class of the input
+  export let noInputStyles = false
 
   export let debug = false
 
@@ -955,7 +957,7 @@
     {/if}
     <input
       type="text"
-      class="{inputClassName ? inputClassName : ''} input autocomplete-input"
+      class="{inputClassName ? inputClassName : ''}  {noInputStyles ? '' : 'input autocomplete-input'}"
       id={inputId ? inputId : ""}
       autocomplete={html5autocomplete ? "on" : "off"}
       {placeholder}


### PR DESCRIPTION
This one is a bit tricky: We had some trouble with the "autocomplete-input" styles and our css-framework. It is not so easy to reset those properly. So I created an option to disable the classes attached to the input.