### PR TITLE
Module structure and github package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.2.4",
   "description": "Autocomplete / Select / Typeahead component made with Svelte 3",
   "svelte": "src/SimpleAutocomplete.svelte",
-  "module": "index.mjs",
-  "main": "index.js",
+  "module": "dist/index.mjs",
+  "main": "dist/index.js",
   "devDependencies": {
     "@babel/core": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
@@ -39,7 +39,8 @@
     "start": "sirv public --single",
     "start:dev": "sirv public --single --dev",
     "test": "jest",
-    "prettier": "prettier --write public src"
+    "prettier": "prettier --write public src",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change the module structure to a more common structure and added "prepare" to scripts.

According to my ticket:
https://github.com/pstanoev/simple-svelte-autocomplete/issues/131