### PR TITLE
Add tabindex support to the input

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -142,6 +142,10 @@
 
   export let debug = false
 
+  // add tabindex support for the input
+  // set standard to 0: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
+  export let tabindex = 0;
+
   // --- Public State ----
 
   // selected item state
@@ -975,6 +979,7 @@
       {disabled}
       {title}
       readonly={readonly || (lock && selectedItem)}
+      tabindex={tabindex}
       bind:this={input}
       bind:value={text}
       on:input={onInput}


### PR DESCRIPTION
I have the problem that my form hast a tab-hierarchy. There is no way to reach the field, without setting the tabindex.
So i added a new property.: tabindex.

the standard is set to "0", so there should no change to previous behavior:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex