### PR TITLE
[no-issue] Added support to scroll-aware list dropdown positioning

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -896,7 +896,21 @@
       return
     }
 
+    setScrollAwareListPosition()
+
     opened = true
+  }
+
+  function setScrollAwareListPosition(){
+    const { height: viewPortHeight } = window.visualViewport
+    const { bottom: inputButtom, height: inputHeight} = input.getBoundingClientRect()
+    const { height: listHeight } = list.getBoundingClientRect()
+
+    if(inputButtom + listHeight > viewPortHeight) {
+      list.style.top = `-${inputHeight + listHeight}px`
+    } else {
+      list.style.top = "0px"
+    }
   }
 
   function close() {
@@ -1226,7 +1240,7 @@
   }
 
   .autocomplete-list.hidden {
-    display: none;
+    visibility: hidden;
   }
 
   .autocomplete.show-clear .autocomplete-clear-button {


### PR DESCRIPTION
If the component was placed on the bottom of a page, the dropdown increased the body size, leading to styling issues (look and feel of the page might be altered due to larger body size).

Regarding the scroll position scenarios the component mimics the behaviour of the built-in <datalist> component:
-if there is not enough room for the list to display below the component, it is displayed above the component.
-if there is enough room for the list to display below the component, it is displayed below the component.

For correct size calculation and to avoid dependency on properly set max-size CSS property the .autocomplete-list.hidden css class was updated to use visibility: hidden instead of display:none. The former results in correct bounding client rect when the list is hidden.