### PR TITLE
Fixed async behavior

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -289,7 +289,7 @@
   }
 
   // -- Reactivity --
-  $: items, prepareListItems()
+  $: items, searchFunction || prepareListItems()
 
   function onSelectedItemChanged() {
     value = valueFunction(selectedItem)

--- a/src/async.test.ts
+++ b/src/async.test.ts
@@ -23,3 +23,35 @@ test("even with the input is focused, the menu is empty", async () => {
   expect(await screen.queryByText('White')).not.toBeInTheDocument()
   expect(await screen.queryByText('Red')).not.toBeInTheDocument()
 })
+
+test("when something is queried, only the matching items are shown", async () => {
+  const { component, container } = render(SimpleAutocomplete, {searchFunction: colors})
+  const queryInput = container.querySelector("input[type='text']");
+
+  await fireEvent.input(queryInput, { target: { value: "white" } })
+
+  expect(await screen.queryByText('White')).toBeInTheDocument()
+  expect(await screen.queryByText('White')).toBeVisible()
+  expect(await screen.queryByText('Red')).not.toBeInTheDocument()
+})
+
+test("when nothing matches the query, no item is show", async () => {
+  const { component, container } = render(SimpleAutocomplete, {searchFunction: colors})
+  const queryInput = container.querySelector("input[type='text']");
+
+  await fireEvent.input(queryInput, { target: { value: "not-a-color" } })
+
+  expect(await screen.queryByText('White')).not.toBeInTheDocument()
+  expect(await screen.queryByText('Red')).not.toBeInTheDocument()
+})
+
+test("when something is queried, the query is highlighted", async () => {
+  const { component, container } = render(SimpleAutocomplete, {searchFunction: colors})
+  const queryInput = container.querySelector("input[type='text']");
+  const list = container.querySelector("autocomplete-list");
+
+  await fireEvent.input(queryInput, { target: { value: "whi" } })
+
+  const white_item = (await screen.queryByText('Whi')).closest(".autocomplete-list-item")
+  expect(white_item).toContainHTML('<b>Whi</b>te')
+})

--- a/src/demo/AsyncExample.svelte
+++ b/src/demo/AsyncExample.svelte
@@ -3,6 +3,10 @@
   import Highlight from "svelte-highlight"
   import xml from "svelte-highlight/languages/xml"
 
+  async function searchColor(keyword, nb_items_max) {
+    return ["White", "Red", "Yellow", "Green", "Blue", "Black", "Mät bläck", "<i>Jét Black</i>"]
+  }
+
   async function searchCountry(keyword) {
     const url =
       "https://restcountries.com/v2/name/" + encodeURIComponent(keyword) + "?fields=name;alpha2Code"
@@ -11,9 +15,22 @@
     return await response.json()
   }
 
+  let selectedColor
   let selectedCountry
 
-  const code = `<script>
+  const colorCode = `<script>
+let selectedColor;
+async function searchColor(keyword) {
+    return ["White", "Red", "Yellow", "Green", "Blue", "Black", "Mät bläck", "<i>Jét Black</i>"]
+}
+<\/script>
+
+<AutoComplete
+    searchFunction={searchColor}
+    bind:selectedItem={selectedColor}
+/>`
+
+  const countryCode = `<script>
 let selectedCountry;
 async function searchCountry(keyword) {
     const url = "https://restcountries.com/v2/name/"
@@ -37,9 +54,32 @@ async function searchCountry(keyword) {
   <h3 class="mt-3">Async example:</h3>
 
   <p>
-    The delay parameter makes the component wait for 200ms after you typed something before
-    generating a request. Set <strong>localFiltering</strong> to false if your search function already
-    returnes filtered results.
+    <code>searchFunction</code> can be used to dynamically generate items.
+  </p>
+
+  <div class="columns">
+    <div class="column is-one-third">
+      <h5>Pick a color:</h5>
+
+      <AutoComplete
+        searchFunction={searchColor}
+        bind:selectedItem={selectedColor}
+      />
+
+      <div style="margin-bottom: 10rem;">
+        <p>Selected color: {JSON.stringify(selectedColor)}</p>
+      </div>
+    </div>
+
+    <div class="column">
+      <Highlight language={xml} code={colorCode} />
+    </div>
+  </div>
+
+  <p>
+    The <code>delay</code> parameter makes the component wait for 200ms after you typed something before
+    generating a request. Set <code>localFiltering</code> to <code>false</code> if your search function already
+    returnes filtered results, so results won't be filtered a second time client-side.
   </p>
 
   <div class="columns">
@@ -61,7 +101,7 @@ async function searchCountry(keyword) {
     </div>
 
     <div class="column">
-      <Highlight language={xml} {code} />
+      <Highlight language={xml} code={countryCode} />
     </div>
   </div>
 


### PR DESCRIPTION
This patch fixes #154, adds tests to avoid regressions on the async side.

`prepareListItems` is not called anymore when a `searchFunction` is defined. This fixes filtering, and query highlighting.

@pstanoev could you review this and release a new version? :pray: :heart: 