### PR TITLE
Fixed minCharactersToSearch behavior with async

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -379,11 +379,12 @@
           console.log("User entered text is empty set the list of items to all items")
         }
       }
-      closeIfMinCharsToSearchReached()
-      if (debug) {
-        console.timeEnd(timerId)
+      if(closeIfMinCharsToSearchReached()) {
+        if (debug) {
+          console.timeEnd(timerId)
+        }
+        return
       }
-      return
     }
 
     if (!searchFunction) {
@@ -828,14 +829,12 @@
       console.log("resetListToAllItemsAndOpen")
     }
 
-    if (!text) {
-      filteredListItems = listItems
+    if (searchFunction && !listItems.length) {
+      search()
     }
 
-    // When an async component is initialized, the item list
-    // must be loaded when the input is focused.
-    else if (!listItems.length && selectedItem && searchFunction) {
-      search()
+    else if (!text) {
+      filteredListItems = listItems
     }
 
     open()
@@ -913,13 +912,20 @@
   }
 
   function notEnoughSearchText() {
-    return minCharactersToSearch > 1 && filteredTextLength < minCharactersToSearch
+    return (
+      minCharactersToSearch > 0 &&
+      filteredTextLength < minCharactersToSearch &&
+      // When no searchFunction is defined, the menu should always open when the input is focused
+      (searchFunction || filteredTextLength > 0)
+    )
   }
 
   function closeIfMinCharsToSearchReached() {
     if (notEnoughSearchText()) {
       close()
+      return true
     }
+    return false
   }
 
   function clear() {

--- a/src/demo/AsyncExample.svelte
+++ b/src/demo/AsyncExample.svelte
@@ -28,6 +28,7 @@ async function searchColor(keyword) {
 <AutoComplete
     searchFunction={searchColor}
     bind:selectedItem={selectedColor}
+    minCharactersToSearch=0
 />`
 
   const countryCode = `<script>
@@ -54,7 +55,9 @@ async function searchCountry(keyword) {
   <h3 class="mt-3">Async example:</h3>
 
   <p>
-    <code>searchFunction</code> can be used to dynamically generate items.
+    <code>searchFunction</code> can be used to dynamically generate items.<br>
+    The function will be called when the input length is at least <code>minCharactersToSearch</code> characters long.
+    If set to 0 the function will be triggered when the input field is focused.
   </p>
 
   <div class="columns">
@@ -64,6 +67,7 @@ async function searchCountry(keyword) {
       <AutoComplete
         searchFunction={searchColor}
         bind:selectedItem={selectedColor}
+        minCharactersToSearch=0
       />
 
       <div style="margin-bottom: 10rem;">


### PR DESCRIPTION
Currently, when the input is focused, the behavior is different if a `searchFunction` is defined or not. When not defined, the menu always open, independently of `minCharactersToSearch`, when defined, the menu nevers opens, independently of `minCharactersToSearch`.

This patch does not change behavior when `searchFunction` is not defined, but when it is and `minCharactersToSearch` is 0, then the menu opens when the input is focused.

I am not sure this is what we want though, I think behavior probably should not be different wether `searchFunction` is defined or not.

What do you think?