### PR TITLE
Added dropdown header and footer slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ async function getItems(keyword) {
 - `item` - change the apearance of items in the dropdown list:
 
 ```html
-<div slot="item" let:item="{item}" let:label="{label}">
+<div slot="item" let:item let:label>
   {@html label}
   <!-- to render the default higliglighted item label -->
   <!-- render anything else -->
@@ -202,7 +202,7 @@ async function getItems(keyword) {
 - `no-results` - customize the div that shows the "no results" text:
 
 ```html
-<div slot="no-results" let:noResultsText={noResultsText}>
+<div slot="no-results" let:noResultsText>
     <span>{noResultsText}</span>
 </div>
 ```
@@ -212,7 +212,7 @@ The noResultsText variable is optional and can be ommited.
 - `loading` - customize the div that shows the "loading" text:
 
 ```html
-<div slot="loading" let:loadingText={loadingText}>
+<div slot="loading" let:loadingText>
     <span>{loadingText}</strong>
 </div>
 ```
@@ -220,10 +220,27 @@ The noResultsText variable is optional and can be ommited.
 - `tag` - customize the tag blocks displayed when multiple selection is enabled:
 
 ```html
-<slot name="tag" let:label="{label}" let:item="{item}" let:unselectItem="{unselectItem}">
+<slot name="tag" let:label let:item let:unselectItem>
   <span class="tag">{label}</span>
   <span class="delete-tag" on:click|preventDefault="{unselectItem(item)}"></span>
 </slot>
+```
+
+- `dropdown-header` - customize what is displayed before the item list in the dropdown. By default there is nothing displayed.
+
+```html
+<div slot="menu-header" let:nbItems let:maxItemsToShowInList>
+  <div class="dropdown-item">Choose between those {nbItems} items</div>
+  <hr class="dropdown-divider">
+</div>
+```
+
+- `dropdown-footer` - customize what is displayed before the item list in the dropdown. By default this is where the `moreItemsText` is displayed if there is too much items to be displayed.
+
+```html
+<div slot="dropdown-footer" let:nbItems  let:maxItemsToShowInList>
+    ...
+</div>
 ```
 
 #### CSS properties

--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -1072,6 +1072,8 @@
     bind:this={list}
   >
     {#if filteredListItems && filteredListItems.length > 0}
+      <slot name="dropdown-header" nbItems={filteredListItems.length} maxItemsToShowInList={maxItemsToShowInList} />
+
       {#each filteredListItems as listItem, i}
         {#if listItem && (maxItemsToShowInList <= 0 || i < maxItemsToShowInList)}
           <div
@@ -1097,6 +1099,7 @@
         {/if}
       {/each}
 
+      <slot name="dropdown-footer" nbItems={filteredListItems.length} maxItemsToShowInList={maxItemsToShowInList}>
       {#if maxItemsToShowInList > 0 && filteredListItems.length > maxItemsToShowInList}
         {#if moreItemsText}
           <div class="autocomplete-list-item-no-results">
@@ -1105,6 +1108,7 @@
           </div>
         {/if}
       {/if}
+      </slot>
     {:else if loading && loadingText}
       <div class="autocomplete-list-item-loading">
         <slot name="loading" {loadingText}>{loadingText}</slot>

--- a/src/demo/CustomizationExample.svelte
+++ b/src/demo/CustomizationExample.svelte
@@ -22,6 +22,16 @@
         <span style="color:{item.code}">{item.code}</span>
     </div>
 
+    <div slot="dropdown-header" let:nbItems let:maxItemsToShowInList>
+        <h5 class="dropdown-item">Choose between those {nbItems} items</h5>
+        <hr class="dropdown-divider">
+    </div>
+
+    <div slot="dropdown-footer" let:nbItems let:maxItemsToShowInList>
+        <hr class="dropdown-divider">
+        <h5 class="dropdown-item">{maxItemsToShowInList} maximum are displayed</h5>
+    </div>
+
     <div slot="no-results" let:noResultsText={noResultsText}>
        <strong>NO RESULTS - {noResultsText}</strong>
     </div>
@@ -37,7 +47,15 @@
   <h3 class="mt-3">Slots</h3>
   <article class="message is-info">
     <div class="message-body">
-      You can use the svelte slots mechanism to customize the copmonent.
+      You can use the svelte slots mechanism to customize the component.
+      <ul>
+        <li><code>item</code>: change the apearance of items in the dropdown list</li>
+        <li><code>no-results</code>:  customize the div that shows the "no results" text</li>
+        <li><code>loading</code>: customize the div that shows the "loading" text</li>
+        <li><code>tag</code>: customize the tag blocks displayed when multiple selection is enabled</li>
+        <li><code>dropdown-header</code>: customize what is displayed before the item list in the dropdown. By default there is nothing displayed.</li>
+        <li><code>dropdown-footer</code>: customize what is displayed before the item list in the dropdown. This is where the <code>moreItemsText</code> is displayed if there is too much items to be displayed.</li>
+      </ul>
     </div>
   </article>
 
@@ -57,7 +75,18 @@
             create={true}
             keywordsFunction={(color) => color.name + " " + color.code}
             placeholder="Please select color"
+            maxItemsToShowInList="100"
           >
+            <div slot="dropdown-header" let:nbItems let:maxItemsToShowInList>
+                <h5 class="dropdown-item">Choose between those {nbItems} items</h5>
+                <hr class="dropdown-divider">
+            </div>
+
+            <div slot="dropdown-footer" let:nbItems let:maxItemsToShowInList>
+                <hr class="dropdown-divider">
+                <h5 class="dropdown-item">{maxItemsToShowInList} maximum are displayed</h5>
+            </div>
+
             <div slot="item" let:item let:label>
               {@html label}
               <span style="color:{item.code}">{item.code}</span>


### PR DESCRIPTION
I added two slots `dropdown-header` and `dropdown-footer` that are displayed before and after the item list.

![Screenshot 2022-04-14 at 15-12-47 Svelte Simple Autocomplete Demo](https://user-images.githubusercontent.com/60163/163398137-1ff96b29-94a5-4e68-ae2c-188aba4b796f.png)
