### PR TITLE
Initialization with the 'text' parameter

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -178,7 +178,7 @@
   let opened = false
   let loading = false
   let highlightIndex = -1
-  export let text
+  export let text = undefined
   let filteredTextLength = 0
 
   // view model
@@ -293,7 +293,9 @@
 
   function onSelectedItemChanged() {
     value = valueFunction(selectedItem)
-    text = !multiple ? safeLabelFunction(selectedItem) : ""
+    if (selectedItem && !multiple) {
+        text = safeLabelFunction(selectedItem)
+    }
 
     filteredListItems = listItems
     onChange(selectedItem)
@@ -602,6 +604,7 @@
       }
       close()
       if (multiple) {
+        text = ""
         input.focus()
       }
     } else {
@@ -684,6 +687,7 @@
     if (selectListItem(listItem)) {
       close()
       if (multiple) {
+        text = ""
         input.focus()
       }
     }

--- a/src/tests/multiple.test.ts
+++ b/src/tests/multiple.test.ts
@@ -21,3 +21,16 @@ test("when selection is multiple, selectedItem is a list", async () => {
 
   expect(component.selectedItem).toStrictEqual(["White", "Red"])
 })
+
+test("multiple widget initialization", async () => {
+  const { component, container } = render(SimpleAutocomplete, {
+      items: colors,
+      multiple: true,
+      selectedItem:["White", "Red"],
+      text: "foobar"
+  })
+  const queryInput = container.querySelector("input[type='text']");
+
+  expect(component.selectedItem).toStrictEqual(["White", "Red"])
+  expect(component.text).toStrictEqual("foobar")
+})

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -57,3 +57,25 @@ test("when something is queried, the query is highlighted", async () => {
   const white_item = (await screen.queryByText('Whi')).closest(".autocomplete-list-item")
   expect(white_item).toContainHTML('<b>Whi</b>te')
 })
+
+test("widget initialization with selectedItem", async () => {
+  const { component, container } = render(SimpleAutocomplete, {
+      items: colors,
+      selectedItem:"White",
+  })
+  const queryInput = container.querySelector("input[type='text']");
+
+  expect(component.selectedItem).toStrictEqual("White")
+  expect(component.text).toStrictEqual("White")
+})
+
+test("widget initialization with text", async () => {
+  const { component, container } = render(SimpleAutocomplete, {
+      items: colors,
+      text:"White",
+  })
+  const queryInput = container.querySelector("input[type='text']");
+
+  expect(component.selectedItem).toBeUndefined()
+  expect(component.text).toStrictEqual("White")
+})


### PR DESCRIPTION
This patch allows to use the `text` parameter to initialize the input value, wether the selection is unique or multiple.