### PR TITLE
Fixed multiple selection clear cross

### DIFF
--- a/demo/MultipleExample.svelte
+++ b/demo/MultipleExample.svelte
@@ -50,7 +50,6 @@ let selectedColorsValues;
             items={colorList}
             labelFieldName="name"
             valueFieldName="id"
-            showClear={true}
             bind:selectedItem={selectedColorsItems}
             bind:value={selectedColorsValues}
           />

--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -311,7 +311,9 @@
 
   $: showList = opened && ((items && items.length > 0) || filteredTextLength > 0)
 
-  $: clearable = showClear || ((lock || multiple) && selectedItem)
+  $: hasSelection = (multiple && selectedItem && selectedItem.length > 0) || (!multiple && selectedItem)
+
+  $: clearable = showClear || ((lock || multiple) && hasSelection)
 
   function prepareUserEnteredText(userEnteredText) {
     if (userEnteredText === undefined || userEnteredText === null) {
@@ -718,7 +720,7 @@
       ArrowUp: up.bind(this),
       Escape: onEsc.bind(this),
       Backspace:
-        multiple && selectedItem && selectedItem.length && !text ? onBackspace.bind(this) : null,
+        multiple && hasSelection && !text ? onBackspace.bind(this) : null,
     }
     const fn = fnmap[key]
     if (typeof fn === "function") {
@@ -1020,7 +1022,7 @@
   <select name={selectName} id={selectId} {multiple}>
     {#if !multiple && value}
       <option {value} selected>{text}</option>
-    {:else if multiple && selectedItem}
+    {:else if multiple && hasSelection}
       {#each selectedItem as i}
         <option value={valueFunction(i, true)} selected>
           {safeLabelFunction(i)}
@@ -1029,7 +1031,7 @@
     {/if}
   </select>
   <div class="input-container">
-    {#if multiple && selectedItem}
+    {#if multiple && hasSelection}
       {#each selectedItem as tagItem}
         <slot name="tag" label={safeLabelFunction(tagItem)} item={tagItem} {unselectItem}>
           <div class="tags has-addons">


### PR DESCRIPTION
`selectedItem` was evaluated to `true` even when it was `[]`, this would make the clear cross being displayed even when selection was empty when `multiple` was true.