### PR TITLE
Fixed some accessibility warnings

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -1145,7 +1145,11 @@
           <slot name="tag" label={safeLabelFunction(tagItem)} item={tagItem} {unselectItem}>
             <div class="tags has-addons">
               <span class="tag">{safeLabelFunction(tagItem)}</span>
-              <span class="tag is-delete" on:click|preventDefault={unselectItem(tagItem)} />
+              <span
+                class="tag is-delete"
+                on:click|preventDefault={unselectItem(tagItem)}
+                on:keypress|preventDefault={(e) => {e.key == "Enter" && unselectItem(tagItem)}}
+              />
             </div>
           </slot>
         </div>
@@ -1178,7 +1182,11 @@
       {...$$restProps}
     />
     {#if clearable}
-      <span on:click={clear} class="autocomplete-clear-button">{@html clearText}</span>
+      <span
+        on:click={clear}
+        on:keypress={(e) => {e.key == "Enter" && clear()}}
+        class="autocomplete-clear-button"
+        >{@html clearText}</span>
     {/if}
   </div>
   <div
@@ -1196,6 +1204,7 @@
             class:selected={i === highlightIndex}
             class:confirmed={isConfirmed(listItem.item)}
             on:click={() => onListItemClick(listItem)}
+            on:keypress={(e) => {e.key == "Enter" && onListItemClick(listItem)}}
             on:pointerenter={() => {
               highlightIndex = i
             }}
@@ -1230,7 +1239,11 @@
         <slot name="loading" {loadingText}>{loadingText}</slot>
       </div>
     {:else if create}
-      <div class="autocomplete-list-item-create" on:click={selectItem}>
+      <div
+        class="autocomplete-list-item-create"
+        on:click={selectItem}
+        on:keypress={(e) => {e.key == "Enter" && selectItem()}}
+      >
         <slot name="create" {createText}>{createText}</slot>
       </div>
     {:else if noResultsText}


### PR DESCRIPTION
The latest svelte versions print warnings where displaying those warnings:

```
(!) Plugin svelte: A11y: visible, non-interactive elements with an on:click event must be accompanied by an on:keydown, on:keyup, or on:keypress event.
src/SimpleAutocomplete.svelte
1146:             <div class="tags has-addons">
1147:               <span class="tag">{safeLabelFunction(tagItem)}</span>
1148:               <span class="tag is-delete" on:click|preventDefault={unselectItem(tagItem)} />
                    ^
1149:             </div>
1150:           </slot>
src/SimpleAutocomplete.svelte
1179:     />
1180:     {#if clearable}
1181:       <span on:click={clear} class="autocomplete-clear-button">{@html clearText}</span>
            ^
1182:     {/if}
1183:   </div>
src/SimpleAutocomplete.svelte
1192:       {#each filteredListItems as listItem, i}
1193:         {#if listItem && (maxItemsToShowInList <= 0 || i < maxItemsToShowInList)}
1194:           <div
                ^
1195:             class="autocomplete-list-item"
1196:             class:selected={i === highlightIndex}
src/SimpleAutocomplete.svelte
1231:       </div>
1232:     {:else if create}
1233:       <div class="autocomplete-list-item-create" on:click={selectItem}>
            ^
1234:         <slot name="create" {createText}>{createText}</slot>
1235:       </div>
```

This is fixed by this patch.