### PR TITLE
fix field not being clear when item change from outside the component

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -320,7 +320,7 @@
 
   function onSelectedItemChanged() {
     value = valueFunction(selectedItem)
-    if (selectedItem && !multiple) {
+    if (!multiple) {
       text = safeLabelFunction(selectedItem)
     }
 


### PR DESCRIPTION
When `onSelectedItemChanged` is called after a reactivity change from outside the component and the new `selectedItem` is `undefined`/`null`, the `text` keep the same previous value, but change the actual value.

The `labelFunction`/`safeLabelFunction` check if the `selectedItem` is `undefined`/`null` and set the correct empty string in the `text`