### PR TITLE
Keep menu closed when locked

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -345,6 +345,8 @@
 
   $: clearable = showClear || ((lock || multiple) && hasSelection)
 
+  $: locked = lock && hasSelection
+
   function prepareUserEnteredText(userEnteredText) {
     if (userEnteredText === undefined || userEnteredText === null) {
       return ""
@@ -596,7 +598,7 @@
       return false
     }
 
-    if (lock && selectedItem) {
+    if (locked) {
       return true
     }
 
@@ -926,7 +928,7 @@
     }
 
     // check if the search text has more than the min chars required
-    if (notEnoughSearchText()) {
+    if (locked || notEnoughSearchText()) {
       return
     }
 
@@ -975,7 +977,6 @@
 
     setTimeout(() => {
       input.focus()
-      close()
     })
   }
 
@@ -1167,7 +1168,7 @@
       {disabled}
       {required}
       {title}
-      readonly={readonly || (lock && selectedItem)}
+      readonly={readonly || locked}
       {tabindex}
       bind:this={input}
       bind:value={text}


### PR DESCRIPTION
Without this patch, when `locked` is true, users can open the menu but cannot select items. This feels a very strange UX to me. Instead I suggest that the menu stays closed until users hit the clear button, and the menu would open automatically at this moment.

Alternatively, we could deselect the item when the input is clicked.