### PR TITLE
Call custom ordering functions when opening the menu with an empty input

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -496,7 +496,7 @@
     return numberOfMatches(obj2, searchWords) - numberOfMatches(obj1, searchWords)
   }
 
-  function processListItems(textFiltered) {
+  function processListItems(textFiltered="") {
     // cleans, filters, orders, and highlights the list items
     prepareListItems()
 
@@ -871,7 +871,7 @@
     if (searchFunction && !listItems.length) {
       search()
     } else if (!text) {
-      filteredListItems = listItems
+      processListItems()
     }
 
     open()


### PR DESCRIPTION
This is useful in cases one want to suggest items when the input is focused, before any input has been written. In such a case we want to call processListItems to sort the suggested items.