### PR TITLE
Fix vertical position of clear button

### DIFF
--- a/src/SimpleAutocomplete.svelte
+++ b/src/SimpleAutocomplete.svelte
@@ -1385,6 +1385,7 @@
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
     z-index: 4;
+    height: 100%;
   }
 
   .autocomplete:not(.show-clear) .autocomplete-clear-button {


### PR DESCRIPTION
The clear button sometimes does not display vertically centred.  This changes its styling so that it always does.